### PR TITLE
Fix Nim errors that are thrown when built-in functions have errors

### DIFF
--- a/src/interpreterObj.nim
+++ b/src/interpreterObj.nim
@@ -5,7 +5,7 @@
 # Created by Nobuharu Shimazu on 2/28/2022
 #
 
-import env, slaptype, error, node
+import env, slaptype, error, node, token
 import tables, strutils
 
 type
@@ -17,7 +17,7 @@ type
     locals*: Table[Expr, int]
   
   FuncType* = ref object of BaseType
-    call*: proc (self: var Interpreter, args: seq[BaseType]): BaseType
+    call*: proc (self: var Interpreter, args: seq[BaseType], token: Token): BaseType
     arity*: proc (): int
   
   Function* = ref object of FuncType


### PR DESCRIPTION
Fix Nim out-of-range errors that are thrown when built-in functions have SLAP errors (e.g. "pop function only accepts a list").