### PR TITLE
Default arguments

### DIFF
--- a/src/builtin.nim
+++ b/src/builtin.nim
@@ -11,7 +11,10 @@ import strutils, tables
 const RuntimeError = "RuntimeError"
 
 proc slapPrintln(self: var Interpreter, args: seq[BaseType], token: Token): BaseType =
-  stdout.write(args[0], "\n")
+  if args.len < 1:
+    stdout.write("\n")
+  else:
+    stdout.write(args[0], "\n")
   return newNull()
 
 proc slapPrint(self: var Interpreter, args: seq[BaseType], token: Token): BaseType =
@@ -47,14 +50,10 @@ proc slapTypeof(self: var Interpreter, args: seq[BaseType], token: Token): BaseT
   else: return newString("unknown")
 
 proc slapInput(self: var Interpreter, args: seq[BaseType], token: Token): BaseType =
-  if not (args[0] of SlapString): error(token, RuntimeError, "input function only accepts a string")
-  stdout.write(SlapString(args[0]).value)
+  if args.len == 1:
+    if not (args[0] of SlapString): error(token, RuntimeError, "input function only accepts a string")
+    stdout.write(SlapString(args[0]).value)
   return newString(readLine(stdin))
-
-proc slapGetStrAt(self: var Interpreter, args: seq[BaseType], token: Token): BaseType =
-  if not (args[1] of SlapInt) or not (args[0] of SlapString):
-    error(token, RuntimeError, "at function only accepts an int and a string")
-  return newString($SlapString(args[0]).value[SlapInt(args[1]).value])
 
 proc slapIsInt(self: var Interpreter, args: seq[BaseType], token: Token): BaseType = return newBool(args[0] of SlapInt)
 
@@ -103,23 +102,22 @@ proc slapValues(self: var Interpreter, args: seq[BaseType], token: Token): BaseT
 
 proc loadBuildins*(): Environment =
   var globals = newEnv()
-  globals.define("println", FuncType(arity: proc(): int = 1, call: slapPrintln))
-  globals.define("print", FuncType(arity: proc(): int = 1, call: slapPrint))
-  globals.define("append", FuncType(arity: proc(): int = 2, call: slapAppend))
-  globals.define("pop", FuncType(arity: proc(): int = 1, call: slapPop))
-  globals.define("len", FuncType(arity: proc(): int = 1, call: slapLen))
-  globals.define("type", FuncType(arity: proc(): int = 1, call: slapTypeof))
-  globals.define("input", FuncType(arity: proc(): int = 1, call: slapInput))
-  globals.define("at", FuncType(arity: proc(): int = 2, call: slapGetStrAt))
-  globals.define("isInt", FuncType(arity: proc(): int = 1, call: slapIsInt))
-  globals.define("isFloat", FuncType(arity: proc(): int = 1, call: slapIsFloat))
-  globals.define("isBool", FuncType(arity: proc(): int = 1, call: slapIsBool))
-  globals.define("isString", FuncType(arity: proc(): int = 1, call: slapIsString))
-  globals.define("isList", FuncType(arity: proc(): int = 1, call: slapIsList))
-  globals.define("isNull", FuncType(arity: proc(): int = 1, call: slapIsNull))
-  globals.define("int", FuncType(arity: proc(): int = 1, call: slapConvertInt))
-  globals.define("string", FuncType(arity: proc(): int = 1, call: slapConvertStr))
-  globals.define("keys", FuncType(arity: proc(): int = 1, call: slapKeys))
-  globals.define("values", FuncType(arity: proc(): int = 1, call: slapValues))
+  globals.define("println", FuncType(arity: proc(): (int, int) = (0, 1), call: slapPrintln))
+  globals.define("print", FuncType(arity: proc(): (int, int) = (1, 1), call: slapPrint))
+  globals.define("append", FuncType(arity: proc(): (int, int) = (2, 2), call: slapAppend))
+  globals.define("pop", FuncType(arity: proc(): (int, int) = (1, 1), call: slapPop))
+  globals.define("len", FuncType(arity: proc(): (int, int) = (1, 1), call: slapLen))
+  globals.define("type", FuncType(arity: proc(): (int, int) = (1, 1), call: slapTypeof))
+  globals.define("input", FuncType(arity: proc(): (int, int) = (0, 1), call: slapInput))
+  globals.define("isInt", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsInt))
+  globals.define("isFloat", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsFloat))
+  globals.define("isBool", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsBool))
+  globals.define("isString", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsString))
+  globals.define("isList", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsList))
+  globals.define("isNull", FuncType(arity: proc(): (int, int) = (1, 1), call: slapIsNull))
+  globals.define("int", FuncType(arity: proc(): (int, int) = (1, 1), call: slapConvertInt))
+  globals.define("string", FuncType(arity: proc(): (int, int) = (1, 1), call: slapConvertStr))
+  globals.define("keys", FuncType(arity: proc(): (int, int) = (1, 1), call: slapKeys))
+  globals.define("values", FuncType(arity: proc(): (int, int) = (1, 1), call: slapValues))
 
   return globals

--- a/src/interpreter.nim
+++ b/src/interpreter.nim
@@ -234,7 +234,7 @@ method eval(self: var Interpreter, expre: CallExpr): BaseType =
   let function = FuncType(callee)
   let (atLeast, atMost) = function.arity()
   if arguments.len > atMost or arguments.len < atLeast:
-    error(expre.paren, RuntimeError, "Expected at least " & $atLeast & " arguments but got " & $arguments.len)
+    error(expre.paren, RuntimeError, "Expected at least " & $atLeast & " argument(s) but got " & $arguments.len)
   return function.call(self, arguments, expre.paren)
 
 # eval GetExpr

--- a/src/interpreterObj.nim
+++ b/src/interpreterObj.nim
@@ -17,7 +17,7 @@ type
   
   FuncType* = ref object of BaseType
     call*: proc (self: var Interpreter, args: seq[BaseType], token: Token): BaseType
-    arity*: proc (): int
+    arity*: proc (): (int, int) # at-least arg length and at-most length
   
   Function* = ref object of FuncType
     name*: string

--- a/src/node.nim
+++ b/src/node.nim
@@ -83,7 +83,7 @@ type
     keyword*: Token
 
   FuncExpr* = ref object of Expr
-    parameters*: seq[Token]
+    parameters*: seq[FuncArg]
     body*: seq[Stmt]
 
 # ----------------- Statements ---------------------
@@ -133,3 +133,12 @@ type
     methods*: seq[FuncStmt]
     classMethods*: seq[FuncStmt]
   
+# ----------------- Non-nodes ---------------------
+  FuncArg* = ref object of RootObj
+
+  DefaultValued* = ref object of FuncArg
+    paramName*: Token
+    default*: Expr
+  
+  RequiredArg* = ref object of FuncArg
+    paramName*: Token

--- a/src/resolver.nim
+++ b/src/resolver.nim
@@ -193,8 +193,18 @@ proc resolveFunction(self: var Resolver, function: FuncExpr, functype: FunctionT
   self.currentFunction = functype
   self.beginScope()
   for param in function.parameters:
-    self.declare(param)
-    self.define(param)
+    var paramName: Token
+    var defaultValue: Expr
+    if param of RequiredArg:
+      paramName = RequiredArg(param).paramName
+    elif param of DefaultValued:
+      paramName = DefaultValued(param).paramName
+      defaultValue = DefaultValued(param).default
+    self.declare(paramName)
+    self.define(paramName)
+    
+    if not defaultValue.isNil: self.resolve(defaultValue)
+    
   self.resolve(function.body)
   self.endScope()
   self.currentFunction = enclosingFunction

--- a/tests/function/default_arg.slap
+++ b/tests/function/default_arg.slap
@@ -1,0 +1,6 @@
+define func(a, b="default") {
+	println(a); # not default a
+	println(b); # default
+}
+
+func("not default a");


### PR DESCRIPTION
```
define test(a, b = "default") {
	println(a);
	println(b);
}
test("a");

# outputs:
# a
# default
```

```
define test(b = "default", a) {
	println(a);
	println(b);
}
test("a");

# error:
1: define test(b = "default", a) {
2:      println(a);
3:      println(b);

SyntaxError: Required argument cannot follow default argument
```

```
define test(a, b = "default") {
	println(a);
	println(b);
}
test();

# error:
3:      println(b);
4: }
5: test();

RuntimeError: Expected at least 1 argument(s) but got 0
```